### PR TITLE
fixes markdown spacing for header in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#awesome-c
+# awesome-c
 
 A curated list of awesome C frameworks, libraries and software.
 


### PR DESCRIPTION
With no space, it renders as a `#` plus text, versus a header, `# awesome-c`; this corrects the missing space.