### PR TITLE
Add json-build and concord

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,3 +985,5 @@ A curated list of awesome C frameworks, libraries and software.
 * [zedshaw/liblcthw](https://github.com/zedshaw/liblcthw) - The library you create when you are done with Learn C The Hard Way
 * [yunnian/php-nsq](https://github.com/yunnian/php-nsq) - a php nsq client write by c extension,the fastest  nsq client
 * [oreboot/oreboot](https://github.com/oreboot/oreboot) - oreboot is a fork of coreboot, with C removed, written in Rust.
+* [lcsmuller/json-build](https://github.com/lcsmuller/json-build) - C89 tiny zero-allocation JSON serializer
+* [Cogmasters/concord](https://github.com/Cogmasters/concord) - A Discord API wrapper library written in C


### PR DESCRIPTION
* json-build is a zero-allocation JSON builder made in C89 and targetting embedded systems
* Concord is a Discord API wrapper library made in C99