### PR TITLE
Add pspdev/pspsdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,3 +829,4 @@ A curated list of awesome C frameworks, libraries and software.
 * [vxunderground/VX-API](https://github.com/vxunderground/VX-API) - Collection of various WINAPI tricks / features used or abused by Malware
 * [particle-iot/device-os](https://github.com/particle-iot/device-os) - Device OS (Firmware) for Particle Devices
 * [Gigoteur/UnicornConsole](https://github.com/Gigoteur/UnicornConsole) - Unicorn Console: create quick game !
+* [pspdev/pspsdk](https://github.com/pspdev/pspsdk) - An open-source SDK for PSP homebrew development.


### PR DESCRIPTION
GitHub Repo: [pspsdk](https://github.com/pspdev/pspsdk)

Repo Description: An open-source SDK for PSP homebrew development.