### PR TITLE
Add naivesystems/analyze to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,3 +882,4 @@ A curated list of awesome C frameworks, libraries and software.
 * [cksystemsteaching/selfie](https://github.com/cksystemsteaching/selfie) - An educational software system of a tiny self-compiling C compiler, a tiny self-executing RISC-V emulator, and a tiny self-hosting RISC-V hypervisor.
 * [vxunderground/VX-API](https://github.com/vxunderground/VX-API) - Collection of various WINAPI tricks / features used or abused by Malware
 * [particle-iot/device-os](https://github.com/particle-iot/device-os) - Device OS (Firmware) for Particle Devices
+* [naivesystems/analyze](https://github.com/naivesystems/analyze) - A static analysis tool for code security and compliance.


### PR DESCRIPTION
NaiveSystems Analyze is a static analysis tool for code security and compliance that supports some popular C coding standards.