### PR TITLE
Add q16-fixed-exp: a Q16.16 fixed-point exp() library for Cortex-M (C + ASM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,3 +1027,4 @@ A curated list of awesome C frameworks, libraries and software.
 * [cksystemsteaching/selfie](https://github.com/cksystemsteaching/selfie) - An educational software system of a tiny self-compiling C compiler, a tiny self-executing RISC-V emulator, and a tiny self-hosting RISC-V hypervisor.
 * [vxunderground/VX-API](https://github.com/vxunderground/VX-API) - Collection of various WINAPI tricks / features used or abused by Malware
 * [particle-iot/device-os](https://github.com/particle-iot/device-os) - Device OS (Firmware) for Particle Devices
+* [q16-fixed-exp](https://github.com/OscarJ12/eudic) – Fast Q16.16 fixed-point exp()/exp_p()/exp_n() for Cortex-M (no FPU), C + armv7m asm


### PR DESCRIPTION
This library implements fixed_mul(), fixed_exp() (for x ≥ 0) and fixed_exp_signed() (full signed support) in Q16.16 format, entirely in integer math—no FPU or divisions. It uses:

Binary decomposition of the fractional part (11-bit resolution) for sub-0.1 % accuracy on positive exponents

LUT + one-point linear interpolation for negative exponents (≤ 0.1 % error over [0,10])

A tiny lookup table (~324 B) and just one extra multiply per call for negatives

Both portable C and highly optimized ARM Cortex-M3 assembly

Based on O. W. Jackson’s TechRxiv paper “A Fixed-Point Binary Decomposition Method for Efficient Exponential Approximation in Embedded Systems” (May 2025):
https://www.techrxiv.org/users/921611/articles/1293706-a-fixed-point-binary-decomposition-method-for-efficient-exponential-approximation-in-embedded-systems

GitHub: https://github.com/you/q16-fixed-exp