### PR TITLE
Adding Fullaxx/fbpanel to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,3 +1070,4 @@ A curated list of awesome C frameworks, libraries and software.
 * [cksystemsteaching/selfie](https://github.com/cksystemsteaching/selfie) - An educational software system of a tiny self-compiling C compiler, a tiny self-executing RISC-V emulator, and a tiny self-hosting RISC-V hypervisor.
 * [vxunderground/VX-API](https://github.com/vxunderground/VX-API) - Collection of various WINAPI tricks / features used or abused by Malware
 * [particle-iot/device-os](https://github.com/particle-iot/device-os) - Device OS (Firmware) for Particle Devices
+* [Fullaxx/fbpanel](https://github.com/Fullaxx/fbpanel) - Lightweight, configurable desktop panel for X11; provides taskbar, system tray, application launcher, pager and clock plugins.


### PR DESCRIPTION
Adding [Fullaxx/fbpanel](https://github.com/Fullaxx/fbpanel) — a lightweight, configurable desktop panel for X11.

fbpanel provides a taskbar, system tray, application launcher, pager, clock and other plugins. It is a plain X11 application with no desktop environment dependency, written in C and licensed under MIT.